### PR TITLE
Changes for containerssh gssapi authentication 

### DIFF
--- a/v8/client/TGSExchange.go
+++ b/v8/client/TGSExchange.go
@@ -91,7 +91,7 @@ func (cl *Client) GetServiceTicket(spn string) (messages.Ticket, types.Encryptio
 	princ := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, spn)
 	realm := cl.Config.ResolveRealm(princ.NameString[len(princ.NameString)-1])
 
-	tgt, skey, err := cl.sessionTGT(realm)
+	tgt, _, skey, err := cl.sessionTGT(realm)
 	if err != nil {
 		return tkt, skey, err
 	}

--- a/v8/client/client.go
+++ b/v8/client/client.go
@@ -250,11 +250,11 @@ func (cl *Client) GetCCache() (*credentials.CCache, error) {
 	}
 	authTime, startTime, endTime, renewTime, _, err := cl.sessionTimes(cl.Credentials.Realm())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get session times while getting cache (%w)", err)
 	}
 	tgtMar, err := tgt.Marshal()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal tft while getting cache (%w)", err)
 	}
 	tgtCred := credentials.Credential{
 		Client: credentials.Principal{

--- a/v8/client/client.go
+++ b/v8/client/client.go
@@ -258,25 +258,25 @@ func (cl *Client) GetCCache() (*credentials.CCache, error) {
 	}
 	tgtCred := credentials.Credential{
 		Client: credentials.Principal{
-			Realm: cl.Credentials.Realm(),
+			Realm:         cl.Credentials.Realm(),
 			PrincipalName: cl.Credentials.CName(),
 		},
 		Server: credentials.Principal{
-			Realm: tgt.Realm,
+			Realm:         tgt.Realm,
 			PrincipalName: tgt.SName,
 		},
-		Key: skey,
-		AuthTime: authTime,
-		StartTime: startTime,
-		EndTime: endTime,
-		RenewTill: renewTime,
+		Key:         skey,
+		AuthTime:    authTime,
+		StartTime:   startTime,
+		EndTime:     endTime,
+		RenewTill:   renewTime,
 		TicketFlags: flags,
-		Ticket: tgtMar,
+		Ticket:      tgtMar,
 	}
 	creds := []credentials.Credential{tgtCred}
 	ccache := credentials.CCacheFromCredentials(creds)
 	ccache.DefaultPrincipal = credentials.Principal{
-		Realm: cl.Credentials.Realm(),
+		Realm:         cl.Credentials.Realm(),
 		PrincipalName: cl.Credentials.CName(),
 	}
 	return ccache, nil

--- a/v8/client/client.go
+++ b/v8/client/client.go
@@ -145,7 +145,7 @@ func (cl *Client) IsConfigured() (bool, error) {
 	}
 	// Client needs to have either a password, keytab or a session already (later when loading from CCache)
 	if !cl.Credentials.HasPassword() && !cl.Credentials.HasKeytab() {
-		authTime, _, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
+		authTime, _, _, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
 		if err != nil || authTime.IsZero() {
 			return false, errors.New("client has neither a keytab nor a password set and no session")
 		}
@@ -169,7 +169,7 @@ func (cl *Client) Login() error {
 		return err
 	}
 	if !cl.Credentials.HasPassword() && !cl.Credentials.HasKeytab() {
-		_, endTime, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
+		_, _, endTime, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
 		if err != nil {
 			return krberror.Errorf(err, krberror.KRBMsgError, "no user credentials available and error getting any existing session")
 		}
@@ -193,7 +193,7 @@ func (cl *Client) Login() error {
 
 // AffirmLogin will only perform an AS exchange with the KDC if the client does not already have a TGT.
 func (cl *Client) AffirmLogin() error {
-	_, endTime, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
+	_, _, endTime, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
 	if err != nil || time.Now().UTC().After(endTime) {
 		err := cl.Login()
 		if err != nil {
@@ -208,14 +208,14 @@ func (cl *Client) realmLogin(realm string) error {
 	if realm == cl.Credentials.Domain() {
 		return cl.Login()
 	}
-	_, endTime, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
+	_, _, endTime, _, _, err := cl.sessionTimes(cl.Credentials.Domain())
 	if err != nil || time.Now().UTC().After(endTime) {
 		err := cl.Login()
 		if err != nil {
 			return fmt.Errorf("could not get valid TGT for client's realm: %v", err)
 		}
 	}
-	tgt, skey, err := cl.sessionTGT(cl.Credentials.Domain())
+	tgt, _, skey, err := cl.sessionTGT(cl.Credentials.Domain())
 	if err != nil {
 		return err
 	}
@@ -241,6 +241,45 @@ func (cl *Client) Destroy() {
 	cl.cache.clear()
 	cl.Credentials = creds
 	cl.Log("client destroyed")
+}
+
+func (cl *Client) GetCCache() (*credentials.CCache, error) {
+	tgt, flags, skey, err := cl.sessionTGT(cl.Credentials.Realm())
+	if err != nil {
+		return nil, err
+	}
+	authTime, startTime, endTime, renewTime, _, err := cl.sessionTimes(cl.Credentials.Realm())
+	if err != nil {
+		return nil, err
+	}
+	tgtMar, err := tgt.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	tgtCred := credentials.Credential{
+		Client: credentials.Principal{
+			Realm: cl.Credentials.Realm(),
+			PrincipalName: cl.Credentials.CName(),
+		},
+		Server: credentials.Principal{
+			Realm: tgt.Realm,
+			PrincipalName: tgt.SName,
+		},
+		Key: skey,
+		AuthTime: authTime,
+		StartTime: startTime,
+		EndTime: endTime,
+		RenewTill: renewTime,
+		TicketFlags: flags,
+		Ticket: tgtMar,
+	}
+	creds := []credentials.Credential{tgtCred}
+	ccache := credentials.CCacheFromCredentials(creds)
+	ccache.DefaultPrincipal = credentials.Principal{
+		Realm: cl.Credentials.Realm(),
+		PrincipalName: cl.Credentials.CName(),
+	}
+	return ccache, nil
 }
 
 // Diagnostics runs a set of checks that the client is properly configured and writes details to the io.Writer provided.

--- a/v8/client/session.go
+++ b/v8/client/session.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jcmturner/gofork/encoding/asn1"
+
 	"github.com/jcmturner/gokrb5/v8/iana/nametype"
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/messages"
@@ -62,9 +64,11 @@ func (s *sessions) get(realm string) (*session, bool) {
 type session struct {
 	realm                string
 	authTime             time.Time
+	startTime            time.Time
 	endTime              time.Time
 	renewTill            time.Time
 	tgt                  messages.Ticket
+	tgtFlags             asn1.BitString
 	sessionKey           types.EncryptionKey
 	sessionKeyExpiration time.Time
 	cancel               chan bool
@@ -75,6 +79,7 @@ type session struct {
 type jsonSession struct {
 	Realm                string
 	AuthTime             time.Time
+	StartTime            time.Time
 	EndTime              time.Time
 	RenewTill            time.Time
 	SessionKeyExpiration time.Time
@@ -91,9 +96,11 @@ func (cl *Client) addSession(tgt messages.Ticket, dep messages.EncKDCRepPart) {
 	s := &session{
 		realm:                realm,
 		authTime:             dep.AuthTime,
+		startTime:            dep.StartTime,
 		endTime:              dep.EndTime,
 		renewTill:            dep.RenewTill,
 		tgt:                  tgt,
+		tgtFlags:             dep.Flags,
 		sessionKey:           dep.Key,
 		sessionKeyExpiration: dep.KeyExpiration,
 	}
@@ -107,9 +114,11 @@ func (s *session) update(tgt messages.Ticket, dep messages.EncKDCRepPart) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.authTime = dep.AuthTime
+	s.startTime = dep.StartTime
 	s.endTime = dep.EndTime
 	s.renewTill = dep.RenewTill
 	s.tgt = tgt
+	s.tgtFlags = dep.Flags
 	s.sessionKey = dep.Key
 	s.sessionKeyExpiration = dep.KeyExpiration
 }
@@ -138,17 +147,17 @@ func (s *session) valid() bool {
 }
 
 // tgtDetails is a thread safe way to get the session's realm, TGT and session key values
-func (s *session) tgtDetails() (string, messages.Ticket, types.EncryptionKey) {
+func (s *session) tgtDetails() (string, messages.Ticket, asn1.BitString, types.EncryptionKey) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	return s.realm, s.tgt, s.sessionKey
+	return s.realm, s.tgt, s.tgtFlags, s.sessionKey
 }
 
 // timeDetails is a thread safe way to get the session's validity time values
-func (s *session) timeDetails() (string, time.Time, time.Time, time.Time, time.Time) {
+func (s *session) timeDetails() (string, time.Time, time.Time, time.Time, time.Time, time.Time) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	return s.realm, s.authTime, s.endTime, s.renewTill, s.sessionKeyExpiration
+	return s.realm, s.startTime, s.authTime, s.endTime, s.renewTill, s.sessionKeyExpiration
 }
 
 // JSON return information about the held sessions in a JSON format.
@@ -162,10 +171,11 @@ func (s *sessions) JSON() (string, error) {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		r, at, et, rt, kt := s.Entries[k].timeDetails()
+		r, st, at, et, rt, kt := s.Entries[k].timeDetails()
 		j := jsonSession{
 			Realm:                r,
 			AuthTime:             at,
+			StartTime:            st,
 			EndTime:              et,
 			RenewTill:            rt,
 			SessionKeyExpiration: kt,
@@ -215,7 +225,7 @@ func (cl *Client) enableAutoSessionRenewal(s *session) {
 
 // renewTGT renews the client's TGT session.
 func (cl *Client) renewTGT(s *session) error {
-	realm, tgt, skey := s.tgtDetails()
+	realm, tgt, _, skey := s.tgtDetails()
 	spn := types.PrincipalName{
 		NameType:   nametype.KRB_NT_SRV_INST,
 		NameString: []string{"krbtgt", realm},
@@ -264,7 +274,7 @@ func (cl *Client) ensureValidSession(realm string) error {
 }
 
 // sessionTGTDetails is a thread safe way to get the TGT and session key values for a realm
-func (cl *Client) sessionTGT(realm string) (tgt messages.Ticket, sessionKey types.EncryptionKey, err error) {
+func (cl *Client) sessionTGT(realm string) (tgt messages.Ticket, flags asn1.BitString, sessionKey types.EncryptionKey, err error) {
 	err = cl.ensureValidSession(realm)
 	if err != nil {
 		return
@@ -274,18 +284,18 @@ func (cl *Client) sessionTGT(realm string) (tgt messages.Ticket, sessionKey type
 		err = fmt.Errorf("could not find TGT session for %s", realm)
 		return
 	}
-	_, tgt, sessionKey = s.tgtDetails()
+	_, tgt, flags, sessionKey = s.tgtDetails()
 	return
 }
 
 // sessionTimes provides the timing information with regards to a session for the realm specified.
-func (cl *Client) sessionTimes(realm string) (authTime, endTime, renewTime, sessionExp time.Time, err error) {
+func (cl *Client) sessionTimes(realm string) (authTime, startTime, endTime, renewTime, sessionExp time.Time, err error) {
 	s, ok := cl.sessions.get(realm)
 	if !ok {
 		err = fmt.Errorf("could not find TGT session for %s", realm)
 		return
 	}
-	_, authTime, endTime, renewTime, sessionExp = s.timeDetails()
+	_, authTime, startTime, endTime, renewTime, sessionExp = s.timeDetails()
 	return
 }
 

--- a/v8/client/session_test.go
+++ b/v8/client/session_test.go
@@ -55,11 +55,11 @@ func TestMultiThreadedClientSession(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer wg.Done()
-			tgt, _, err := cl.sessionTGT("TEST.GOKRB5")
+			tgt, _, _, err := cl.sessionTGT("TEST.GOKRB5")
 			if err != nil || tgt.Realm != "TEST.GOKRB5" {
 				t.Logf("error getting session: %v", err)
 			}
-			_, _, _, r, _ := cl.sessionTimes("TEST.GOKRB5")
+			_, _, _, _, r, _ := cl.sessionTimes("TEST.GOKRB5")
 			fmt.Fprintf(ioutil.Discard, "%v", r)
 		}()
 		time.Sleep(time.Second)
@@ -90,7 +90,7 @@ func TestClient_AutoRenew_Goroutine(t *testing.T) {
 	n := runtime.NumGoroutine()
 	for i := 0; i < 24; i++ {
 		time.Sleep(time.Second * 5)
-		_, endTime, _, _, err := cl.sessionTimes("TEST.GOKRB5")
+		_, _, endTime, _, _, err := cl.sessionTimes("TEST.GOKRB5")
 		if err != nil {
 			t.Errorf("could not get client's session: %v", err)
 		}
@@ -123,6 +123,7 @@ func TestSessions_JSON(t *testing.T) {
 		e := &session{
 			realm:                realm,
 			authTime:             time.Unix(int64(0+i), 0).UTC(),
+			startTime:            time.Unix(int64(1+i), 0).UTC(),
 			endTime:              time.Unix(int64(10+i), 0).UTC(),
 			renewTill:            time.Unix(int64(20+i), 0).UTC(),
 			sessionKeyExpiration: time.Unix(int64(30+i), 0).UTC(),
@@ -137,6 +138,7 @@ func TestSessions_JSON(t *testing.T) {
   {
     "Realm": "test0",
     "AuthTime": "1970-01-01T00:00:00Z",
+    "StartTime": "1970-01-01T00:00:01Z",
     "EndTime": "1970-01-01T00:00:10Z",
     "RenewTill": "1970-01-01T00:00:20Z",
     "SessionKeyExpiration": "1970-01-01T00:00:30Z"
@@ -144,6 +146,7 @@ func TestSessions_JSON(t *testing.T) {
   {
     "Realm": "test1",
     "AuthTime": "1970-01-01T00:00:01Z",
+    "StartTime": "1970-01-01T00:00:02Z",
     "EndTime": "1970-01-01T00:00:11Z",
     "RenewTill": "1970-01-01T00:00:21Z",
     "SessionKeyExpiration": "1970-01-01T00:00:31Z"
@@ -151,6 +154,7 @@ func TestSessions_JSON(t *testing.T) {
   {
     "Realm": "test2",
     "AuthTime": "1970-01-01T00:00:02Z",
+    "StartTime": "1970-01-01T00:00:03Z",
     "EndTime": "1970-01-01T00:00:12Z",
     "RenewTill": "1970-01-01T00:00:22Z",
     "SessionKeyExpiration": "1970-01-01T00:00:32Z"

--- a/v8/credentials/ccache.go
+++ b/v8/credentials/ccache.go
@@ -1,10 +1,10 @@
 package credentials
 
 import (
-	"fmt"
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"time"
@@ -72,15 +72,15 @@ func LoadCCache(cpath string) (*CCache, error) {
 	return c, err
 }
 
-func CCacheFromCredentials(creds []Credential) (*CCache) {
+func CCacheFromCredentials(creds []Credential) *CCache {
 	credentials := make([]*Credential, len(creds))
 	for i, cred := range creds {
 		credentials[i] = &cred
 	}
 	c := CCache{
-		Version: 4,
+		Version:          4,
 		DefaultPrincipal: creds[0].Client,
-		Credentials: credentials,
+		Credentials:      credentials,
 	}
 
 	return &c
@@ -136,7 +136,7 @@ func (c *CCache) Marshal() ([]byte, error) {
 
 	var endian binary.ByteOrder
 	endian = c.getEndianess()
-	if (c.Version == 4) {
+	if c.Version == 4 {
 		header, err := c.writeHeader(endian)
 		if err != nil {
 			return b, err
@@ -191,7 +191,7 @@ func (c *CCache) writeHeader(e binary.ByteOrder) ([]byte, error) {
 		b = append(b, writeUint16(field.length, e)...)
 		b = append(b, field.value...)
 	}
-	if uint16(len(b)) - 2 != c.Header.length {
+	if uint16(len(b))-2 != c.Header.length {
 		return b, fmt.Errorf("Header length and real length differ %d != %d", len(b), c.Header.length)
 	}
 	return b, nil
@@ -224,7 +224,7 @@ func (c *CCache) writePrincipal(p Principal, e binary.ByteOrder) ([]byte, error)
 	}
 	count := uint32(len(p.PrincipalName.NameString))
 	if c.Version == 1 {
-		count += 1;
+		count += 1
 	}
 	b = append(b, writeUint32(count, e)...)
 
@@ -431,13 +431,13 @@ func readTimestamp(b []byte, p *int, e *binary.ByteOrder) time.Time {
 	return time.Unix(int64(readInt32(b, p, e)), 0)
 }
 
-func writeUint16(i uint16, e binary.ByteOrder) ([]byte) {
+func writeUint16(i uint16, e binary.ByteOrder) []byte {
 	b := make([]byte, 2)
 	e.PutUint16(b, i)
 	return b
 }
 
-func writeUint32(i uint32, e binary.ByteOrder) ([]byte) {
+func writeUint32(i uint32, e binary.ByteOrder) []byte {
 	b := make([]byte, 4)
 	e.PutUint32(b, i)
 	return b

--- a/v8/credentials/ccache.go
+++ b/v8/credentials/ccache.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"fmt"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -21,7 +22,7 @@ const (
 type CCache struct {
 	Version          uint8
 	Header           header
-	DefaultPrincipal principal
+	DefaultPrincipal Principal
 	Credentials      []*Credential
 	Path             string
 }
@@ -37,16 +38,16 @@ type headerField struct {
 	value  []byte
 }
 
-// Credential cache entry principal struct.
-type principal struct {
+// Credential cache entry Principal struct.
+type Principal struct {
 	Realm         string
 	PrincipalName types.PrincipalName
 }
 
 // Credential holds a Kerberos client's ccache credential information.
 type Credential struct {
-	Client       principal
-	Server       principal
+	Client       Principal
+	Server       Principal
 	Key          types.EncryptionKey
 	AuthTime     time.Time
 	StartTime    time.Time
@@ -71,6 +72,27 @@ func LoadCCache(cpath string) (*CCache, error) {
 	return c, err
 }
 
+func CCacheFromCredentials(creds []Credential) (*CCache) {
+	credentials := make([]*Credential, len(creds))
+	for i, cred := range creds {
+		credentials[i] = &cred
+	}
+	c := CCache{
+		Version: 4,
+		DefaultPrincipal: creds[0].Client,
+		Credentials: credentials,
+	}
+
+	return &c
+}
+
+func (c *CCache) getEndianess() binary.ByteOrder {
+	if (c.Version == 1 || c.Version == 2) && isNativeEndianLittle() {
+		return binary.LittleEndian
+	}
+	return binary.BigEndian
+}
+
 // Unmarshal a byte slice of credential cache data into CCache type.
 func (c *CCache) Unmarshal(b []byte) error {
 	p := 0
@@ -88,10 +110,8 @@ func (c *CCache) Unmarshal(b []byte) error {
 	p++
 	//Version 1 or 2 of the file format uses native byte order for integer representations. Versions 3 & 4 always uses big-endian byte order
 	var endian binary.ByteOrder
-	endian = binary.BigEndian
-	if (c.Version == 1 || c.Version == 2) && isNativeEndianLittle() {
-		endian = binary.LittleEndian
-	}
+	endian = c.getEndianess()
+
 	if c.Version == 4 {
 		err := parseHeader(b, &p, c, &endian)
 		if err != nil {
@@ -107,6 +127,36 @@ func (c *CCache) Unmarshal(b []byte) error {
 		c.Credentials = append(c.Credentials, cred)
 	}
 	return nil
+}
+
+func (c *CCache) Marshal() ([]byte, error) {
+	var b []byte
+	b = append(b, 5)
+	b = append(b, c.Version)
+
+	var endian binary.ByteOrder
+	endian = c.getEndianess()
+	if (c.Version == 4) {
+		header, err := c.writeHeader(endian)
+		if err != nil {
+			return b, err
+		}
+		b = append(b, header...)
+	}
+
+	princ, err := c.writePrincipal(c.DefaultPrincipal, endian)
+	if err != nil {
+		return b, err
+	}
+	b = append(b, princ...)
+
+	for i := 0; i < len(c.Credentials); i++ {
+		var cred []byte
+		cred = c.writeCredential(c.Credentials[i], endian)
+		b = append(b, cred...)
+	}
+
+	return b, nil
 }
 
 func parseHeader(b []byte, p *int, c *CCache, e *binary.ByteOrder) error {
@@ -130,8 +180,25 @@ func parseHeader(b []byte, p *int, c *CCache, e *binary.ByteOrder) error {
 	return nil
 }
 
+func (c *CCache) writeHeader(e binary.ByteOrder) ([]byte, error) {
+	var b []byte
+	i := make([]byte, 2)
+	e.PutUint16(i, c.Header.length)
+	b = append(b, i...)
+	for _, field := range c.Header.fields {
+		b = append(b, writeUint16(field.tag, e)...)
+		// assert field.length == len(value)
+		b = append(b, writeUint16(field.length, e)...)
+		b = append(b, field.value...)
+	}
+	if uint16(len(b)) - 2 != c.Header.length {
+		return b, fmt.Errorf("Header length and real length differ %d != %d", len(b), c.Header.length)
+	}
+	return b, nil
+}
+
 // Parse the Keytab bytes of a principal into a Keytab entry's principal.
-func parsePrincipal(b []byte, p *int, c *CCache, e *binary.ByteOrder) (princ principal) {
+func parsePrincipal(b []byte, p *int, c *CCache, e *binary.ByteOrder) (princ Principal) {
 	if c.Version != 1 {
 		//Name Type is omitted in version 1
 		princ.PrincipalName.NameType = readInt32(b, p, e)
@@ -148,6 +215,34 @@ func parsePrincipal(b []byte, p *int, c *CCache, e *binary.ByteOrder) (princ pri
 		princ.PrincipalName.NameString = append(princ.PrincipalName.NameString, string(readBytes(b, p, int(l), e)))
 	}
 	return princ
+}
+
+func (c *CCache) writePrincipal(p Principal, e binary.ByteOrder) ([]byte, error) {
+	var b []byte
+	if c.Version != 1 {
+		b = append(b, writeUint32(uint32(p.PrincipalName.NameType), e)...)
+	}
+	count := uint32(len(p.PrincipalName.NameString))
+	if c.Version == 1 {
+		count += 1;
+	}
+	b = append(b, writeUint32(count, e)...)
+
+	realmLen := len(p.Realm)
+	b = append(b, writeUint32(uint32(realmLen), e)...)
+	for i := 0; i < realmLen; i++ {
+		b = append(b, p.Realm[i])
+	}
+
+	for i := 0; i < len(p.PrincipalName.NameString); i++ {
+		component := p.PrincipalName.NameString[i]
+		b = append(b, writeUint32(uint32(len(component)), e)...)
+		for j := 0; j < len(component); j++ {
+			b = append(b, component[j])
+		}
+	}
+
+	return b, nil
 }
 
 func parseCredential(b []byte, p *int, c *CCache, e *binary.ByteOrder) (cred *Credential, err error) {
@@ -186,6 +281,59 @@ func parseCredential(b []byte, p *int, c *CCache, e *binary.ByteOrder) (cred *Cr
 	cred.Ticket = readData(b, p, e)
 	cred.SecondTicket = readData(b, p, e)
 	return
+}
+
+func (c *CCache) writeCredential(cred *Credential, e binary.ByteOrder) []byte {
+	var b bytes.Buffer
+
+	client, _ := c.writePrincipal(cred.Client, e)
+	b.Write(client)
+
+	server, _ := c.writePrincipal(cred.Server, e)
+	b.Write(server)
+
+	b.Write(writeUint16(uint16(cred.Key.KeyType), e))
+
+	if c.Version == 3 {
+		// Repeated twice in version 3
+		b.Write(writeUint16(uint16(cred.Key.KeyType), e))
+	}
+
+	b.Write(writeUint32(uint32(len(cred.Key.KeyValue)), e))
+	b.Write(cred.Key.KeyValue)
+
+	b.Write(writeUint32(uint32(cred.AuthTime.Unix()), e))
+	b.Write(writeUint32(uint32(cred.StartTime.Unix()), e))
+	b.Write(writeUint32(uint32(cred.EndTime.Unix()), e))
+	b.Write(writeUint32(uint32(cred.RenewTill.Unix()), e))
+
+	if cred.IsSKey {
+		b.WriteByte(byte(1))
+	} else {
+		b.WriteByte(byte(0))
+	}
+
+	b.Write(cred.TicketFlags.Bytes)
+
+	b.Write(writeUint32(uint32(len(cred.Addresses)), e))
+	for i := 0; i < len(cred.Addresses); i++ {
+		address := cred.Addresses[i]
+		b.Write(writeUint16(uint16(address.AddrType), e))
+		b.Write(address.Address)
+	}
+
+	b.Write(writeUint32(uint32(len(cred.AuthData)), e))
+	for i := 0; i < len(cred.AuthData); i++ {
+		authEntry := cred.AuthData[i]
+		b.Write(writeUint16(uint16(authEntry.ADType), e))
+		b.Write(authEntry.ADData)
+	}
+
+	b.Write(writeUint32(uint32(len(cred.Ticket)), e))
+	b.Write(cred.Ticket)
+	b.Write(writeUint32(uint32(len(cred.SecondTicket)), e))
+	b.Write(cred.SecondTicket)
+	return b.Bytes()
 }
 
 // GetClientPrincipalName returns a PrincipalName type for the client the credentials cache is for.
@@ -281,6 +429,18 @@ func readAuthDataEntry(b []byte, p *int, e *binary.ByteOrder) types.Authorizatio
 // Read bytes representing a timestamp.
 func readTimestamp(b []byte, p *int, e *binary.ByteOrder) time.Time {
 	return time.Unix(int64(readInt32(b, p, e)), 0)
+}
+
+func writeUint16(i uint16, e binary.ByteOrder) ([]byte) {
+	b := make([]byte, 2)
+	e.PutUint16(b, i)
+	return b
+}
+
+func writeUint32(i uint32, e binary.ByteOrder) ([]byte) {
+	b := make([]byte, 4)
+	e.PutUint32(b, i)
+	return b
 }
 
 // Read bytes representing an eight bit integer.

--- a/v8/credentials/ccache.go
+++ b/v8/credentials/ccache.go
@@ -187,7 +187,6 @@ func (c *CCache) writeHeader(e binary.ByteOrder) ([]byte, error) {
 	b = append(b, i...)
 	for _, field := range c.Header.fields {
 		b = append(b, writeUint16(field.tag, e)...)
-		// assert field.length == len(value)
 		b = append(b, writeUint16(field.length, e)...)
 		b = append(b, field.value...)
 	}

--- a/v8/messages/APRep.go
+++ b/v8/messages/APRep.go
@@ -3,12 +3,19 @@ package messages
 import (
 	"fmt"
 	"time"
+	"crypto/rand"
+	"math"
+	"math/big"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	"github.com/jcmturner/gokrb5/v8/iana"
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
 	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/types"
+	"github.com/jcmturner/gokrb5/v8/crypto"
 )
 
 // APRep implements RFC 4120 KRB_AP_REP: https://tools.ietf.org/html/rfc4120#section-5.5.2.
@@ -46,4 +53,85 @@ func (a *EncAPRepPart) Unmarshal(b []byte) error {
 		return krberror.Errorf(err, krberror.EncodingError, "AP_REP unmarshal error")
 	}
 	return nil
+}
+
+func (a *EncAPRepPart) Marshal() ([]byte, error) {
+	mk, err := asn1.Marshal(*a)
+	if err != nil {
+		return []byte{}, err
+	}
+	mk = asn1tools.AddASNAppTag(mk, asnAppTag.EncAPRepPart)
+	return mk, nil
+}
+
+func (a *APRep) Marshal() ([]byte, error) {
+	rep, err := asn1.Marshal(*a)
+	if err != nil {
+		return rep, err
+	}
+	rep = asn1tools.AddASNAppTag(rep, asnAppTag.APREP)
+	return rep, nil
+}
+
+func (a *EncAPRepPart) GenerateSeqNumber() error {
+	seq, err := rand.Int(rand.Reader, big.NewInt(math.MaxUint32))
+	if err != nil {
+		return err
+	}
+	a.SequenceNumber = seq.Int64()
+	return nil
+}
+
+func (a *APRep) DecryptEncryptedPart(sessionKey types.EncryptionKey) (EncAPRepPart, error) {
+	encPart := EncAPRepPart{}
+
+	ab, e := crypto.DecryptEncPart(a.EncPart, sessionKey, uint32(keyusage.AP_REP_ENCPART))
+	if e != nil {
+		return encPart, fmt.Errorf("error decrypting encrypted part: %v", e)
+	}
+	err := encPart.Unmarshal(ab)
+	if err != nil {
+		return encPart, fmt.Errorf("error unmarshaling encrypted part: %v", err)
+	}
+	return encPart, nil
+
+}
+
+func EncryptPart(tkt Ticket, sessionKey types.EncryptionKey, part EncAPRepPart) (types.EncryptedData, error){
+	var ed types.EncryptedData
+	m, err:= part.Marshal()
+	if err != nil {
+		return types.EncryptedData{}, krberror.Errorf(err, krberror.EncodingError, "marshaling error of EncryptedData form of APRep")
+	}
+
+	ed, err = crypto.GetEncryptedData(m, sessionKey, uint32(keyusage.AP_REP_ENCPART), tkt.EncPart.KVNO)
+	if err != nil {
+		return ed, krberror.Errorf(err, krberror.EncryptingError, "error encrypting APRepPart")
+	}
+	return ed, nil
+}
+
+func NewAPRep(tkt Ticket, authenticator types.Authenticator) (APRep, error) {
+	part := EncAPRepPart{
+		CTime: authenticator.CTime,
+		Cusec: authenticator.Cusec,
+	}
+	err := part.GenerateSeqNumber()
+	if err != nil {
+		return APRep{}, err
+	}
+	part.Subkey = authenticator.SubKey
+
+	ed, err := EncryptPart(tkt, tkt.DecryptedEncPart.Key, part)
+	//ed, err := encryptPart(tkt, authenticator.SubKey, part)
+	if err != nil {
+		return APRep{}, err
+	}
+
+	a := APRep{
+		PVNO: iana.PVNO,
+		MsgType: msgtype.KRB_AP_REP,
+		EncPart: ed,
+	}
+	return a, nil
 }

--- a/v8/messages/APRep.go
+++ b/v8/messages/APRep.go
@@ -1,21 +1,21 @@
 package messages
 
 import (
-	"fmt"
-	"time"
 	"crypto/rand"
+	"fmt"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/iana"
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
-	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
 	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
+	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/types"
-	"github.com/jcmturner/gokrb5/v8/crypto"
 )
 
 // APRep implements RFC 4120 KRB_AP_REP: https://tools.ietf.org/html/rfc4120#section-5.5.2.
@@ -97,9 +97,9 @@ func (a *APRep) DecryptEncryptedPart(sessionKey types.EncryptionKey) (EncAPRepPa
 
 }
 
-func EncryptPart(tkt Ticket, sessionKey types.EncryptionKey, part EncAPRepPart) (types.EncryptedData, error){
+func EncryptPart(tkt Ticket, sessionKey types.EncryptionKey, part EncAPRepPart) (types.EncryptedData, error) {
 	var ed types.EncryptedData
-	m, err:= part.Marshal()
+	m, err := part.Marshal()
 	if err != nil {
 		return types.EncryptedData{}, krberror.Errorf(err, krberror.EncodingError, "marshaling error of EncryptedData form of APRep")
 	}
@@ -129,7 +129,7 @@ func NewAPRep(tkt Ticket, authenticator types.Authenticator) (APRep, error) {
 	}
 
 	a := APRep{
-		PVNO: iana.PVNO,
+		PVNO:    iana.PVNO,
 		MsgType: msgtype.KRB_AP_REP,
 		EncPart: ed,
 	}

--- a/v8/messages/KRBCred.go
+++ b/v8/messages/KRBCred.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/credentials"
 	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
 	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
 	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/types"
-	"github.com/jcmturner/gokrb5/v8/credentials"
 )
 
 type marshalKRBCred struct {
@@ -61,18 +61,18 @@ func (k *KRBCred) ToCredentials() ([]credentials.Credential, error) {
 	for i, tinfo := range k.DecryptedEncPart.TicketInfo {
 		cred := credentials.Credential{
 			Client: credentials.Principal{
-				Realm: tinfo.PRealm,
+				Realm:         tinfo.PRealm,
 				PrincipalName: tinfo.PName,
 			},
 			Server: credentials.Principal{
-				Realm: tinfo.SRealm,
+				Realm:         tinfo.SRealm,
 				PrincipalName: tinfo.SName,
 			},
-			Key: tinfo.Key,
-			AuthTime: tinfo.AuthTime,
-			StartTime: tinfo.StartTime,
-			EndTime: tinfo.EndTime,
-			RenewTill: tinfo.RenewTill,
+			Key:         tinfo.Key,
+			AuthTime:    tinfo.AuthTime,
+			StartTime:   tinfo.StartTime,
+			EndTime:     tinfo.EndTime,
+			RenewTill:   tinfo.RenewTill,
 			TicketFlags: tinfo.Flags,
 		}
 		ticket, err := k.Tickets[i].Marshal()

--- a/v8/spnego/http.go
+++ b/v8/spnego/http.go
@@ -233,8 +233,8 @@ const (
 	spnegoNegTokenRespIncompleteKRB5 = "Negotiate oRQwEqADCgEBoQsGCSqGSIb3EgECAg=="
 	// sessionCredentials is the session value key holding the credentials jcmturner/goidentity/Identity object.
 	sessionCredentials = "github.com/jcmturner/gokrb5/v8/sessionCredentials"
-	// ctxCredentials is the SPNEGO context key holding the credentials jcmturner/goidentity/Identity object.
-	ctxCredentials = "github.com/jcmturner/gokrb5/v8/ctxCredentials"
+	// CtxCredentials is the SPNEGO context key holding the credentials jcmturner/goidentity/Identity object.
+	CtxCredentials = "github.com/jcmturner/gokrb5/v8/ctxCredentials"
 	// HTTPHeaderAuthRequest is the header that will hold authn/z information.
 	HTTPHeaderAuthRequest = "Authorization"
 	// HTTPHeaderAuthResponse is the header that will hold SPNEGO data from the server.
@@ -288,7 +288,7 @@ func SPNEGOKRB5Authenticate(inner http.Handler, kt *keytab.Keytab, settings ...f
 
 		if authed {
 			// Authentication successful; get user's credentials from the context
-			id := ctx.Value(ctxCredentials).(*credentials.Credentials)
+			id := ctx.Value(CtxCredentials).(*credentials.Credentials)
 			// Create a new session if a session manager has been configured
 			err = newSession(spnego, r, w, id)
 			if err != nil {

--- a/v8/spnego/negotiationToken.go
+++ b/v8/spnego/negotiationToken.go
@@ -123,7 +123,7 @@ func (n *NegTokenInit) Verify() (bool, gssapi.Status) {
 	}
 	// There should be some mechtoken bytes for a KRB5Token (other mech types are not supported)
 	mt := new(KRB5Token)
-	mt.settings = n.settings
+	mt.Settings = n.settings
 	if n.mechToken == nil {
 		err := mt.Unmarshal(n.MechTokenBytes)
 		if err != nil {
@@ -202,7 +202,7 @@ func (n *NegTokenResp) Verify() (bool, gssapi.Status) {
 			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
 		}
 		mt := new(KRB5Token)
-		mt.settings = n.settings
+		mt.Settings = n.settings
 		if n.mechToken == nil {
 			err := mt.Unmarshal(n.ResponseToken)
 			if err != nil {

--- a/v8/types/Authenticator.go
+++ b/v8/types/Authenticator.go
@@ -3,11 +3,11 @@ package types
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"math/big"
 	"time"
-	"encoding/binary"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
@@ -38,17 +38,17 @@ type Authenticator struct {
 	SubKey            EncryptionKey     `asn1:"explicit,optional,tag:6"`
 	SeqNumber         int64             `asn1:"explicit,optional,tag:7"`
 	AuthorizationData AuthorizationData `asn1:"explicit,optional,tag:8"`
-	Delegation        CredDelegation     `asn1:"optional"`
+	Delegation        CredDelegation    `asn1:"optional"`
 }
 
 // RFC1964 Section 1.1
 type CredDelegation struct {
-	BndLength    uint32
-	Bnd          []byte
-	Flags        uint32
-	DelegOption  uint16
-	DelegLength  uint16
-	Deleg        []byte
+	BndLength   uint32
+	Bnd         []byte
+	Flags       uint32
+	DelegOption uint16
+	DelegLength uint16
+	Deleg       []byte
 }
 
 // NewAuthenticator creates a new Authenticator.
@@ -123,7 +123,7 @@ func (c *CredDelegation) Unmarshal(b []byte) error {
 
 	c.DelegOption = binary.LittleEndian.Uint16(b[24:26])
 	c.DelegLength = binary.LittleEndian.Uint16(b[26:28])
-	c.Deleg = b[28:c.DelegLength+28]
+	c.Deleg = b[28 : c.DelegLength+28]
 
 	return nil
 }

--- a/v8/types/Authenticator.go
+++ b/v8/types/Authenticator.go
@@ -124,7 +124,7 @@ func (c *CredDelegation) HasDelegation() bool {
 func (c *CredDelegation) Unmarshal(b []byte) error {
 	c.BndLength = binary.LittleEndian.Uint32(b[0:4])
 	if c.BndLength != 16 {
-		return fmt.Errorf("Invalid BndLength")
+		return fmt.Errorf("Invalid BndLength of %d", c.BndLength)
 	}
 	c.Bnd = b[4:20]
 	c.Flags = binary.LittleEndian.Uint32(b[20:24])

--- a/v8/types/Authenticator.go
+++ b/v8/types/Authenticator.go
@@ -15,6 +15,16 @@ import (
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
 )
 
+// RFC 4121 Section 4.1.1.1
+const (
+	Flag_Deleg    = 1
+	Flag_Mutual   = 2
+	Flag_Replay   = 4
+	Flag_Sequence = 8
+	Flag_Conf     = 16
+	Flag_Integ    = 32
+)
+
 // Authenticator - A record containing information that can be shown to have been recently generated using the session
 // key known only by the client and server.
 // https://tools.ietf.org/html/rfc4120#section-5.5.1
@@ -76,6 +86,10 @@ func (a *Authenticator) GenerateSeqNumberAndSubKey(keyType int32, keySize int) e
 	return nil
 }
 
+func (a *Authenticator) HasCredDelegation() bool {
+	return a.Delegation.Flags&Flag_Deleg != 0
+}
+
 // Unmarshal bytes into the Authenticator.
 func (a *Authenticator) Unmarshal(b []byte) error {
 	_, err := asn1.UnmarshalWithParams(b, a, fmt.Sprintf("application,explicit,tag:%v", asnAppTag.Authenticator))
@@ -95,7 +109,7 @@ func (a *Authenticator) Marshal() ([]byte, error) {
 	return b, nil
 }
 
-func (c* CredDelegation) Unmarshal(b []byte) error {
+func (c *CredDelegation) Unmarshal(b []byte) error {
 	c.BndLength = binary.LittleEndian.Uint32(b[0:4])
 	if c.BndLength != 16 {
 		return fmt.Errorf("Invalid BndLength")

--- a/v8/types/Authenticator.go
+++ b/v8/types/Authenticator.go
@@ -95,10 +95,10 @@ func (a *Authenticator) GetCredDelegation() (*CredDelegation, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error unmarshalling KRB_CRED packet in Authenticator")
 	}
-	if del.Flags & Flag_Deleg != 0 {
+	if del.Flags & Flag_Deleg == 0 {
 		return nil, nil
 	}
-	return nil, nil
+	return &del, nil
 }
 
 // Unmarshal bytes into the Authenticator.


### PR DESCRIPTION
These are the changes necessary for gssapi to work with containerssh. Additionally support for writing credential caches is added to allow for credential delegation.

Note that this is merge request targets the new containerssh branch to avoid conflicts with upstream.